### PR TITLE
Rename `contentsInsets` to `contentInset`.

### DIFF
--- a/Sources/Tokenizer/Elements/Implementation/ScrollView.swift
+++ b/Sources/Tokenizer/Elements/Implementation/ScrollView.swift
@@ -31,7 +31,7 @@ public class ScrollView: Container {
 public class ScrollViewProperties: ViewProperties {
     public let contentOffset: AssignablePropertyDescription<Point>
     public let contentSize: AssignablePropertyDescription<Size>
-    public let contentInsets: AssignablePropertyDescription<EdgeInsets>
+    public let contentInset: AssignablePropertyDescription<EdgeInsets>
     public let isScrollEnabled: AssignablePropertyDescription<Bool>
     public let isDirectionalLockEnabled: AssignablePropertyDescription<Bool>
     public let isPagingEnabled: AssignablePropertyDescription<Bool>
@@ -52,7 +52,7 @@ public class ScrollViewProperties: ViewProperties {
     public required init(configuration: Configuration) {
         contentOffset = configuration.property(name: "contentOffset")
         contentSize = configuration.property(name: "contentSize")
-        contentInsets = configuration.property(name: "contentInsets")
+        contentInset = configuration.property(name: "contentInset")
         isScrollEnabled = configuration.property(name: "isScrollEnabled", key: "scrollEnabled")
         isDirectionalLockEnabled = configuration.property(name: "isDirectionalLockEnabled", key: "directionalLockEnabled")
         isPagingEnabled = configuration.property(name: "isPagingEnabled", key: "pagingEnabled")


### PR DESCRIPTION
Fixes #82.