### PR TITLE
Deduplicate constraints.

### DIFF
--- a/Example/Source/Component/Playground/ExampleRootView.ui.xml
+++ b/Example/Source/Component/Playground/ExampleRootView.ui.xml
@@ -46,9 +46,9 @@
     <View
         backgroundColor="blue"
         layout:id="test"
-        layout:leading="[!(horizontal == compact) and (vertical == regular) and pad or width :lt 100] super;
-                        [(horizontal == compact or vertical == compact or pad) and height :gte 20] self;
-                        [false] :gte 10"
+        layout:leading="[!(horizontal == compact) and (vertical == regular) and pad or width :lt 100] coolConstraint = super;
+                        [(horizontal == compact or vertical == compact or pad) and height :gte 20] coolConstraint = self;
+                        [false] uniqueConstraint = :gte 10"
         layout:top="safeAreaLayoutGuide.top"
         layout:width="100"
         layout:height="50"/>

--- a/Sources/Generator/UIGenerator.swift
+++ b/Sources/Generator/UIGenerator.swift
@@ -25,6 +25,7 @@ public class UIGenerator: Generator {
         if root.isAnonymous {
             l("\(modifier)final class \(root.type): ViewBase<Void, Void>") { }
         }
+        
         let constraintFields = root.children.flatMap(self.constraintFields)
         try l("extension \(root.type): ReactantUI" + (root.isRootView ? ", RootView" : "")) {
             if root.isRootView {
@@ -365,17 +366,17 @@ public class UIGenerator: Generator {
     }
 
     private func constraintFields(element: UIElement) -> [String] {
-        var fields = [] as [String]
+        var fields = Set<String>()
         for constraint in element.layout.constraints {
             guard let field = constraint.field else { continue }
 
-            fields.append(field)
+            fields.insert(field)
         }
 
         if let container = element as? UIContainer {
             return fields + container.children.flatMap(constraintFields)
         } else {
-            return fields
+            return Array(fields)
         }
     }
 


### PR DESCRIPTION
This makes it a bit more difficult to debug when you accidentally name two constraints the same and they start activating/deactivating at the same time for no apparent reason.
However it is necessary if we want to use conditions. Naming two constraints which are the same just for different conditions produced an error until now because of duplication.