### PR TITLE
Fire a warning when the project contains an empty `ui.xml` file, but do not crash.

### DIFF
--- a/Sources/reactant-ui/GenerateCommand.swift
+++ b/Sources/reactant-ui/GenerateCommand.swift
@@ -147,7 +147,7 @@ class GenerateCommand: Command {
 
             let xml = SWXMLHash.parse(data)
 
-            let node = xml["Component"].element!
+            guard let node = xml["Component"].element else { continue }
             var definition: ComponentDefinition
             do {
                 if let type: String = xml["Component"].value(ofAttribute: "type") {


### PR DESCRIPTION
Unwrap the `Component` safely so that the generator doesn’t crash upon seeing an empty file.

Fixes #89.