### PR TITLE
Fire a warning when using `extend` in `ui.xml` without specifying `root=true`.

### DIFF
--- a/Example/Source/Component/Playground/ExampleRootView.ui.xml
+++ b/Example/Source/Component/Playground/ExampleRootView.ui.xml
@@ -5,7 +5,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://schema.reactant.tech/ui http://schema.reactant.tech/ui.xsd
                         http://schema.reactant.tech/layout http://schema.reactant.tech/layout.xsd"
-
     rootView="true"
     backgroundColor="black">
 
@@ -59,7 +58,6 @@
         layout:width="100"
         layout:height="50"/>
 
-    <!-- <View> <Label/> </View> -->
     <View/>
     <ImageView
         layout:edges="super"


### PR DESCRIPTION
Fixes #93.