### PR TITLE
Fix `EdgeInsets` materializing.

### DIFF
--- a/ReactantUI.xcodeproj/project.pbxproj
+++ b/ReactantUI.xcodeproj/project.pbxproj
@@ -183,7 +183,6 @@
 		18449279209225BE0080B743 /* ReactantLiveUI.h in Headers */ = {isa = PBXBuildFile; fileRef = 184492782092255A0080B743 /* ReactantLiveUI.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1844928120922AE20080B743 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1844927C20922AE10080B743 /* Info.plist */; };
 		1844928220922AE20080B743 /* LabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1844927D20922AE10080B743 /* LabelTests.swift */; };
-		1844928320922AE20080B743 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1844927F20922AE10080B743 /* Info.plist */; };
 		1844928420922AE20080B743 /* Tokenizer_iOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1844928020922AE10080B743 /* Tokenizer_iOSTests.swift */; };
 		18758FE420D980FF004C6690 /* Example.hyperdrive.xml in Resources */ = {isa = PBXBuildFile; fileRef = 18758FE320D980FF004C6690 /* Example.hyperdrive.xml */; };
 		18758FE620D9BBB0004C6690 /* ReactantThemeSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18758FE520D9BBB0004C6690 /* ReactantThemeSelector.swift */; };
@@ -225,6 +224,7 @@
 		68178D63211C23F000633BCC /* ViewCollapseAxis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68178D62211C23F000633BCC /* ViewCollapseAxis.swift */; };
 		681A1E1620D3CA8D00109BEC /* ButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681A1E1520D3CA8D00109BEC /* ButtonTests.swift */; };
 		6826D8F020F6726D00BC43B7 /* SimpleProcedure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6826D8EE20F6725A00BC43B7 /* SimpleProcedure.swift */; };
+		683032E321401B550036B985 /* EdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683032E221401B550036B985 /* EdgeInsets.swift */; };
 		6836D5F920B8404F00FD2DF8 /* UIView+traits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 689FA0B7209CB2A200B39225 /* UIView+traits.swift */; };
 		6836D5FB20B86C3500FD2DF8 /* AttributedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836D5FA20B86C3500FD2DF8 /* AttributedText.swift */; };
 		68692E7620D2881B001CCC01 /* AnonymousTestComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68692E7520D2881B001CCC01 /* AnonymousTestComponent.swift */; };
@@ -247,6 +247,7 @@
 		687D4DA220C1B27200F890CB /* SupportedPropertyTypeContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687D4DA120C1B27200F890CB /* SupportedPropertyTypeContext.swift */; };
 		687D4DA820C5582000F890CB /* ElementAssignablePropertyDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687D4DA720C5582000F890CB /* ElementAssignablePropertyDescription.swift */; };
 		687D4DAA20C5582800F890CB /* ElementAssignableProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687D4DA920C5582800F890CB /* ElementAssignableProperty.swift */; };
+		68808B9C2142579D0053A832 /* XCTAssertThrowsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68808B9B2142579D0053A832 /* XCTAssertThrowsError.swift */; };
 		6893A6B520BBF30E004802E4 /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6893A6B320BBF0DA004802E4 /* URL.swift */; };
 		6893A6B720BBF48C004802E4 /* UnderlineStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6893A6B620BBF48C004802E4 /* UnderlineStyle.swift */; };
 		6893A6B920BBFA77004802E4 /* WritingDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6893A6B820BBFA77004802E4 /* WritingDirection.swift */; };
@@ -556,6 +557,7 @@
 		68178D62211C23F000633BCC /* ViewCollapseAxis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewCollapseAxis.swift; sourceTree = "<group>"; };
 		681A1E1520D3CA8D00109BEC /* ButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonTests.swift; sourceTree = "<group>"; };
 		6826D8EE20F6725A00BC43B7 /* SimpleProcedure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleProcedure.swift; sourceTree = "<group>"; };
+		683032E221401B550036B985 /* EdgeInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeInsets.swift; sourceTree = "<group>"; };
 		6836D5FA20B86C3500FD2DF8 /* AttributedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedText.swift; sourceTree = "<group>"; };
 		68692E7520D2881B001CCC01 /* AnonymousTestComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymousTestComponent.swift; sourceTree = "<group>"; };
 		68692E7920D2B22F001CCC01 /* ElementMapping+mapFrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ElementMapping+mapFrom.swift"; sourceTree = "<group>"; };
@@ -577,6 +579,7 @@
 		687D4DA120C1B27200F890CB /* SupportedPropertyTypeContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedPropertyTypeContext.swift; sourceTree = "<group>"; };
 		687D4DA720C5582000F890CB /* ElementAssignablePropertyDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElementAssignablePropertyDescription.swift; sourceTree = "<group>"; };
 		687D4DA920C5582800F890CB /* ElementAssignableProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElementAssignableProperty.swift; sourceTree = "<group>"; };
+		68808B9B2142579D0053A832 /* XCTAssertThrowsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTAssertThrowsError.swift; sourceTree = "<group>"; };
 		6893A6B320BBF0DA004802E4 /* URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
 		6893A6B620BBF48C004802E4 /* UnderlineStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnderlineStyle.swift; sourceTree = "<group>"; };
 		6893A6B820BBFA77004802E4 /* WritingDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritingDirection.swift; sourceTree = "<group>"; };
@@ -1173,6 +1176,7 @@
 			children = (
 				1844928020922AE10080B743 /* Tokenizer_iOSTests.swift */,
 				71D94EC320935F8E007D83A1 /* ConstraintConditionTests.swift */,
+				683032E221401B550036B985 /* EdgeInsets.swift */,
 			);
 			path = Tokenizer;
 			sourceTree = "<group>";
@@ -1320,6 +1324,7 @@
 				68692E7B20D2B26D001CCC01 /* TestOptions.swift */,
 				68130657211834D8007DB5F2 /* TestLiveUIConfiguration.swift */,
 				68130650211828DD007DB5F2 /* StringTemplate.swift */,
+				68808B9B2142579D0053A832 /* XCTAssertThrowsError.swift */,
 			);
 			path = ReactantUI;
 			sourceTree = "<group>";
@@ -1621,7 +1626,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1844928320922AE20080B743 /* Info.plist in Resources */,
 				1844928120922AE20080B743 /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2103,6 +2107,7 @@
 				681A1E1620D3CA8D00109BEC /* ButtonTests.swift in Sources */,
 				68130651211828DD007DB5F2 /* StringTemplate.swift in Sources */,
 				68692E7A20D2B22F001CCC01 /* ElementMapping+mapFrom.swift in Sources */,
+				683032E321401B550036B985 /* EdgeInsets.swift in Sources */,
 				687822EC20CFF6BB00838C96 /* NSObjectProtocol+where.swift in Sources */,
 				68692E7E20D2B2FF001CCC01 /* Snapshotter.swift in Sources */,
 				6813065C21183D38007DB5F2 /* ViewTests.swift in Sources */,
@@ -2112,6 +2117,7 @@
 				68692E7C20D2B26D001CCC01 /* TestOptions.swift in Sources */,
 				68130658211834D8007DB5F2 /* TestLiveUIConfiguration.swift in Sources */,
 				1844928420922AE20080B743 /* Tokenizer_iOSTests.swift in Sources */,
+				68808B9C2142579D0053A832 /* XCTAssertThrowsError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/ReactantUI/XCTAssertThrowsError.swift
+++ b/Tests/ReactantUI/XCTAssertThrowsError.swift
@@ -1,0 +1,17 @@
+//
+//  XCTAssertThrowsError.swift
+//  LiveUI-iOSTests
+//
+//  Created by Matyáš Kříž on 07/09/2018.
+//
+
+import XCTest
+
+func XCTAssertThrowsError(message: String = "", file: StaticString = #file, line: UInt = #line, _ block: () throws -> ()) {
+    do {
+        try block()
+
+        let msg = (message == "") ? "Tested block did not throw error as expected." : message
+        XCTFail(msg, file: file, line: line)
+    } catch {}
+}

--- a/Tests/Tokenizer/EdgeInsets.swift
+++ b/Tests/Tokenizer/EdgeInsets.swift
@@ -1,0 +1,288 @@
+//
+//  EdgeInsets.swift
+//  LiveUI-iOSTests
+//
+//  Created by Matyáš Kříž on 05/09/2018.
+//  Copyright © 2018 Brightify. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import ReactantLiveUI
+
+class EdgeInsetsTests: XCTestCase {
+    func testTop() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "top: \(number)")
+            XCTAssertEqual(edgeInsets.top, number)
+            XCTAssertEqual(edgeInsets.left, 0)
+            XCTAssertEqual(edgeInsets.bottom, 0)
+            XCTAssertEqual(edgeInsets.right, 0)
+        }
+    }
+
+    func testLeft() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "left: \(number)")
+            XCTAssertEqual(edgeInsets.left, number)
+            XCTAssertEqual(edgeInsets.bottom, 0)
+            XCTAssertEqual(edgeInsets.right, 0)
+            XCTAssertEqual(edgeInsets.top, 0)
+        }
+    }
+
+    func testBottom() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "bottom: \(number)")
+            XCTAssertEqual(edgeInsets.bottom, number)
+            XCTAssertEqual(edgeInsets.right, 0)
+            XCTAssertEqual(edgeInsets.top, 0)
+            XCTAssertEqual(edgeInsets.left, 0)
+        }
+    }
+
+    func testRight() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "right: \(number)")
+            XCTAssertEqual(edgeInsets.right, number)
+            XCTAssertEqual(edgeInsets.top, 0)
+            XCTAssertEqual(edgeInsets.left, 0)
+            XCTAssertEqual(edgeInsets.bottom, 0)
+        }
+    }
+
+    func testHorizontal() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "horizontal: \(number)")
+            XCTAssertEqual(edgeInsets.left, number)
+            XCTAssertEqual(edgeInsets.right, number)
+            XCTAssertEqual(edgeInsets.top, 0)
+            XCTAssertEqual(edgeInsets.bottom, 0)
+        }
+    }
+
+    func testVertical() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "vertical: \(number)")
+            XCTAssertEqual(edgeInsets.top, number)
+            XCTAssertEqual(edgeInsets.bottom, number)
+            XCTAssertEqual(edgeInsets.left, 0)
+            XCTAssertEqual(edgeInsets.right, 0)
+        }
+    }
+
+    func testAll() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "all: \(number)")
+            XCTAssertEqual(edgeInsets.top, number)
+            XCTAssertEqual(edgeInsets.left, number)
+            XCTAssertEqual(edgeInsets.bottom, number)
+            XCTAssertEqual(edgeInsets.right, number)
+        }
+    }
+
+    func testAllNoLabel() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "\(number)")
+            XCTAssertEqual(edgeInsets.top, number)
+            XCTAssertEqual(edgeInsets.left, number)
+            XCTAssertEqual(edgeInsets.bottom, number)
+            XCTAssertEqual(edgeInsets.right, number)
+        }
+    }
+
+    func testHorizontalVerticalNoLabel() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "\(number), \(number / 2)")
+            XCTAssertEqual(edgeInsets.top, number / 2)
+            XCTAssertEqual(edgeInsets.left, number)
+            XCTAssertEqual(edgeInsets.bottom, number / 2)
+            XCTAssertEqual(edgeInsets.right, number)
+        }
+    }
+
+    func testAllSidesNoLabel() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "\(number), \(number / 2), \(number / 4), \(number / 8)")
+            XCTAssertEqual(edgeInsets.top, number)
+            XCTAssertEqual(edgeInsets.left, number / 2)
+            XCTAssertEqual(edgeInsets.bottom, number / 4)
+            XCTAssertEqual(edgeInsets.right, number / 8)
+        }
+    }
+
+    func testAllSides() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "top: \(number), left: \(number / 2), bottom: \(number / 4), right: \(number / 8)")
+            XCTAssertEqual(edgeInsets.top, number)
+            XCTAssertEqual(edgeInsets.left, number / 2)
+            XCTAssertEqual(edgeInsets.bottom, number / 4)
+            XCTAssertEqual(edgeInsets.right, number / 8)
+        }
+    }
+
+    func testAllSidesDifferentPositioning() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "bottom: \(number), left: \(number / 2), right: \(number / 4), top: \(number / 8)")
+            XCTAssertEqual(edgeInsets.top, number / 8)
+            XCTAssertEqual(edgeInsets.left, number / 2)
+            XCTAssertEqual(edgeInsets.bottom, number)
+            XCTAssertEqual(edgeInsets.right, number / 4)
+        }
+    }
+
+    func testThreeSides() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "bottom: \(number), left: \(number / 2), right: \(number / 4)")
+            XCTAssertEqual(edgeInsets.top, 0)
+            XCTAssertEqual(edgeInsets.left, number / 2)
+            XCTAssertEqual(edgeInsets.bottom, number)
+            XCTAssertEqual(edgeInsets.right, number / 4)
+        }
+    }
+
+    func testTwoSides() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "bottom: \(number), right: \(number / 4)")
+            XCTAssertEqual(edgeInsets.top, 0)
+            XCTAssertEqual(edgeInsets.left, 0)
+            XCTAssertEqual(edgeInsets.bottom, number)
+            XCTAssertEqual(edgeInsets.right, number / 4)
+        }
+
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "left: \(number / 2), right: \(number / 4)")
+            XCTAssertEqual(edgeInsets.top, 0)
+            XCTAssertEqual(edgeInsets.left, number / 2)
+            XCTAssertEqual(edgeInsets.bottom, 0)
+            XCTAssertEqual(edgeInsets.right, number / 4)
+        }
+    }
+
+    func testOneSideAndOneDimension() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "bottom: \(number), horizontal: \(number / 2)")
+            XCTAssertEqual(edgeInsets.top, 0)
+            XCTAssertEqual(edgeInsets.left, number / 2)
+            XCTAssertEqual(edgeInsets.bottom, number)
+            XCTAssertEqual(edgeInsets.right, number / 2)
+        }
+
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "right: \(number), vertical: \(number / 2)")
+            XCTAssertEqual(edgeInsets.top, number / 2)
+            XCTAssertEqual(edgeInsets.left, 0)
+            XCTAssertEqual(edgeInsets.bottom, number / 2)
+            XCTAssertEqual(edgeInsets.right, number)
+        }
+    }
+
+    func testTwoSidesAndOneDimension() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "right: \(number), vertical: \(number / 2), left: \(number / 4)")
+            XCTAssertEqual(edgeInsets.top, number / 2)
+            XCTAssertEqual(edgeInsets.left, number / 4)
+            XCTAssertEqual(edgeInsets.bottom, number / 2)
+            XCTAssertEqual(edgeInsets.right, number)
+        }
+
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "bottom: \(number), top: \(number / 2), horizontal: \(number / 4)")
+            XCTAssertEqual(edgeInsets.top, number / 2)
+            XCTAssertEqual(edgeInsets.left, number / 4)
+            XCTAssertEqual(edgeInsets.bottom, number)
+            XCTAssertEqual(edgeInsets.right, number / 4)
+        }
+    }
+
+    func testTwoDimensions() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            let edgeInsets = try EdgeInsets.materialize(from: "vertical: \(number), horizontal: \(number / 2)")
+            XCTAssertEqual(edgeInsets.top, number)
+            XCTAssertEqual(edgeInsets.left, number / 2)
+            XCTAssertEqual(edgeInsets.bottom, number)
+            XCTAssertEqual(edgeInsets.right, number / 2)
+        }
+    }
+
+    // MARK:- Failure scenario tests
+    func testMultipleTop() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            XCTAssertThrowsError {
+                _ = try EdgeInsets.materialize(from: "top: \(number), top: \(number / 2)")
+            }
+        }
+
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            XCTAssertThrowsError {
+                _ = try EdgeInsets.materialize(from: "top: \(number), vertical: \(number / 2)")
+            }
+        }
+
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            XCTAssertThrowsError {
+                _ = try EdgeInsets.materialize(from: "all: \(number), top: \(number / 2)")
+            }
+        }
+    }
+
+    func testMultipleLeft() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            XCTAssertThrowsError {
+                _ = try EdgeInsets.materialize(from: "left: \(number), left: \(number / 2)")
+            }
+        }
+
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            XCTAssertThrowsError {
+                _ = try EdgeInsets.materialize(from: "left: \(number), horizontal: \(number / 2)")
+            }
+        }
+
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            XCTAssertThrowsError {
+                _ = try EdgeInsets.materialize(from: "all: \(number), left: \(number / 2)")
+            }
+        }
+    }
+
+    func testMultipleBottom() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            XCTAssertThrowsError {
+                _ = try EdgeInsets.materialize(from: "bottom: \(number), bottom: \(number / 2)")
+            }
+        }
+
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            XCTAssertThrowsError {
+                _ = try EdgeInsets.materialize(from: "bottom: \(number), vertical: \(number / 2)")
+            }
+        }
+
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            XCTAssertThrowsError {
+                _ = try EdgeInsets.materialize(from: "all: \(number), bottom: \(number / 2)")
+            }
+        }
+    }
+
+    func testMultipleRight() throws {
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            XCTAssertThrowsError {
+                _ = try EdgeInsets.materialize(from: "right: \(number), right: \(number / 2)")
+            }
+        }
+
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            XCTAssertThrowsError {
+                _ = try EdgeInsets.materialize(from: "right: \(number), horizontal: \(number / 2)")
+            }
+        }
+
+        for number in stride(from: -10.0 as Float, to: 10.0, by: 1) {
+            XCTAssertThrowsError {
+                _ = try EdgeInsets.materialize(from: "right: \(number / 2), all: \(number)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
There was a bug causing it to set horizontal and vertical insets if there were two values no matter if they were named. Test string is "top: 10, right: 2".

Also added tests for `EdgeInsets`.